### PR TITLE
Add raster function

### DIFF
--- a/geotask/geotask.py
+++ b/geotask/geotask.py
@@ -97,3 +97,35 @@ class Map(ipyleaflet.Map):
                 data = shp.__geo_interface__
 
         self.add_geojson(data, name, **kwargs)
+
+    
+    def add_raster(self, data, name="raster", **kwargs):
+        """
+        Adds a raster layer to the current map.
+
+        Args:
+            data (str or dict): The path to the raster file as a string, or a dictionary representing the raster file.
+            name (str, optional): The name of the layer. Defaults to "raster".
+            **kwargs: Arbitrary keyword arguments.
+
+        Raises:
+            TypeError: If the data is neither a string nor a dictionary representing a raster file.
+
+        Returns:
+            None
+        """
+        import rasterio
+        import numpy as np
+
+        if isinstance(data, str):
+            with rasterio.open(data) as src:
+                data = src.read(1)
+                data = np.ma.masked_where(data == src.nodata, data)
+                data = data.filled(fill_value=0)
+                data = data.tolist()
+
+        if "opacity" not in kwargs:
+            kwargs["opacity"] = 0.7
+
+        layer = ipyleaflet.ImageOverlay(url=data, name=name, **kwargs)
+        self.add(layer)


### PR DESCRIPTION
This PR adds an `add_raster` method to the `Map` class.

```python
import geotask

m = geotask.Map()
m.add_raster(filename)
m
```